### PR TITLE
Habilitando o pacote Laravel CORS nos Middlewares

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ class Kernel extends HttpKernel
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
         \App\Http\Middleware\TrustProxies::class,
+	    \Barryvdh\Cors\HandleCors::class,
     ];
 
     /**


### PR DESCRIPTION
Após a instalação do pacote Laravel CORS pelo composer, é necessário
habilitá-lo nos middlewares para ser possível controlar o CORS.