### PR TITLE
165752459 | Upload de imagens 1 a 1

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Helpers;
+
+class Helpers
+{
+    public function __construct()
+    {
+
+    }
+
+    /**
+     * Retorna false se o model for passar de 10 fotos
+     *
+     * @return boolean
+     */
+    public static function checkUploadLimit($model, $upload_count)
+    {
+        $model_fotos_count = $model->fotos()->count();
+
+        return $model_fotos_count + $upload_count <= 10;
+    }
+}

--- a/app/Http/Controllers/FotoAPIController.php
+++ b/app/Http/Controllers/FotoAPIController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Response;
+use App\Jobs\RemoverImagem;
+use Illuminate\Http\Request;
+use App\Http\Controllers\AppBaseController;
+
+class FotoAPIController extends AppBaseController
+{
+    /**
+     * Remove a imagem do banco e invoca um job para excluir do Cloudinary
+     *
+     * @return void
+     */
+    public function remover($imagem_id)
+    {
+        $this->dispatch(new RemoverImagem($imagem_id));
+        return Response::json('Imagem removida com sucesso', 200);
+    }
+
+}

--- a/app/Jobs/RemoverImagem.php
+++ b/app/Jobs/RemoverImagem.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class RemoverImagem implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    private $imagem_id;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($imagem_id)
+    {
+        $this->imagem_id = $imagem_id;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $foto = \App\Models\Foto::find($this->imagem_id);
+        $retornoCloudinary = \Cloudder::destroyImage($foto->cloudinary_id);
+        $foto->delete();
+    }
+}

--- a/app/Jobs/SincronizarComCloudinary.php
+++ b/app/Jobs/SincronizarComCloudinary.php
@@ -35,7 +35,6 @@ class SincronizarComCloudinary implements ShouldQueue
         $publicId = uniqid('vestylle_upload_') . rand(1,420);
         FotoRepository::sendToCloudinary($this->foto, $publicId, config('cloudinary.CLOUDINARY_CLOUD_FOLDER'));
         FotoRepository::deleteLocal($this->foto->id);
-        sleep(1);
     }
 
     /**

--- a/resources/js/components/VueImageSlider.vue
+++ b/resources/js/components/VueImageSlider.vue
@@ -1,10 +1,11 @@
 <template>
-    <div class="row slider-container">
+    <div class="row slider-container" v-if="images.length > 0">
         <div class="col">
             <a class="prev-image-link" @click="prev"><i class="fa fa-chevron-left"></i></a>
         </div>
         <div class="col" v-for="number in [currentNumber]">
-          <img class="slider-image" :alt="'Foto indisponível'" :src="currentImage"/>
+          <button type="button" class="btn btn-danger remove-img-button" title="Excluir imagem" @click="removeImg(currentImage)"><i class="fa fa-trash"></i></button>
+          <img class="slider-image" :alt="'Foto indisponível'" :src="currentImage.urlCloudinary"/>
         </div>
         <div class="col">
             <a class="next-image-link" @click="next"><i class="fa fa-chevron-right"></i></a>
@@ -27,15 +28,34 @@
             },
             prev: function() {
                 this.currentNumber -= 1
+            },
+            removeImg(currentImage) {
+                const imgIndex = this.images.indexOf(currentImage);
+                axios.delete('/imagens/' + currentImage.id,
+                    {},
+                    {
+                        headers: {
+                            'Content-Type': 'multipart/form-data'
+                        }
+                    }
+                ).then(function(data) {
+                    this.images.splice(imgIndex, 1 );
+                    this.next();
+                    swal({
+                        title: 'Imagem removida com sucesso',
+                        type: 'success',
+                        showConfirmButton: true
+                    });
+                }.bind(this)).catch(function(data) {
+                    console.log('error');
+                });
             }
         },
         computed: {
             currentImage: function() {
               const currentNumber = this.currentNumber;
               const images = this.images;
-              console.log(images);
-              console.log(images[Math.abs(currentNumber) % images.length].urlCloudinary);
-              return images[Math.abs(currentNumber) % images.length].urlCloudinary;
+              return images[Math.abs(currentNumber) % images.length];
             }
         }
     }
@@ -63,6 +83,13 @@
     .slider-image {
         height: 30em;
         width: 30em;
+        object-fit: cover;
+        animation: fadein 0.8s;
+    }
+
+    .remove-img-button {
+        position: absolute;
+        margin-left: 23em;
         animation: fadein 0.8s;
     }
 

--- a/resources/js/components/VueUploadMultipleImage.vue
+++ b/resources/js/components/VueUploadMultipleImage.vue
@@ -38,7 +38,7 @@
             handleFiles() {
                 let uploadedFiles = this.$refs.files.files;
 
-                if (uploadedFiles.length > 10) {
+                if (uploadedFiles.length > 10 || this.files.length == 10) {
                     swal({
                         title: 'Ops!',
                         type: 'warning',
@@ -152,6 +152,7 @@
     }
 
     div.file-listing img{
+        object-fit: cover;
         height: 200px;
         width: 200px;
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,7 +16,7 @@ Route::group(['middleware' => ['auth:api']], function () {
 
     Route::resource('cupons', 'CuponAPIController')->except(['update', 'destroy','store']);
     Route::resource('ofertas', 'OfertaAPIController')->except(['update', 'destroy','store']);
-
+    Route::delete('imagens/{imagem_id}', 'FotoAPIController@remover');
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,5 +36,6 @@ Route::group(['middleware' => ['role:admin']], function () {
     Route::resource('lojas', 'LojaController');
 
     Route::post('upload_image', 'UploadImageController@sendFiles');
+    Route::delete('imagens/{imagem_id}', 'FotoAPIController@remover');
 });
 


### PR DESCRIPTION
Comportamento atual: no upload de imagens nos edits de cupons/ofertas, as imagens novas substituem as velhas, e as velhas ficariam no cloudinary.

Comportamento implementado: acumula imagens sobre as entidades até um máximo de 10. Caso extrapole, a entidade é atualizada com os demais dados e mensagens são exibidas avisando sobre o upload falhar e informando que o dado foi atualizado.

Também implementa um botão no slider de imagens para invocar um job de deletar imagens