### PR TITLE
Feature/165947767 - Métodos para Mapear Data de Nascimento ao sincronizar Usuário com Banco Vestylle

### DIFF
--- a/app/Helpers/VestylleDBHelper.php
+++ b/app/Helpers/VestylleDBHelper.php
@@ -128,6 +128,27 @@ class VestylleDBHelper
         return $result;
     }
 
+    /**
+     * Metodo para obter a data de nascimento de uma pessoa
+     *
+     * @param Pessoa $pessoa
+     * @return array || false - O resultado da query ou false.
+     */
+    public function getNascimentoPessoa(Pessoa $pessoa)
+    {
+        $query = "SELECT NASC FROM vegas_teste.pesdepen WHERE IDPESSOA = $pessoa->id_vestylle AND (TIPO = 'PRINCI' 
+        OR TIPO = '') LIMIT 1" ;
+
+        try {
+            $result = $this->query()->select($query);
+        } catch (\Exception $e) {
+            \Log::error("\n[ERRO] - Erro ao obter data de nascimento uma pessoa. Log: " . $e->getMessage());
+            return false;
+        }
+
+        return $result;
+    }
+
 
     /**
      * Metodo para obter a data da ultima compra de uma pessoa

--- a/app/Http/Controllers/API/PessoaAPIController.php
+++ b/app/Http/Controllers/API/PessoaAPIController.php
@@ -84,6 +84,7 @@ class PessoaAPIController extends AppBaseController
             $this->pessoaRepository->updatePontosPessoa($pessoa);
             $this->pessoaRepository->updateVencimentoPontosPessoa($pessoa);
             $this->pessoaRepository->updateDataUltimaCompraPessoa($pessoa);
+            $this->pessoaRepository->updateNascimentoPessoa($pessoa);
         }
 
         $token = $this->pessoaRepository->login($pessoa, $request);
@@ -146,6 +147,7 @@ class PessoaAPIController extends AppBaseController
             $this->pessoaRepository->updatePontosPessoa($pessoa);
             $this->pessoaRepository->updateVencimentoPontosPessoa($pessoa);
             $this->pessoaRepository->updateDataUltimaCompraPessoa($pessoa);
+            $this->pessoaRepository->updateNascimentoPessoa($pessoa);
         }
 
         return $this->sendResponse($pessoa->toArray(), 'Pessoa atualizada com sucesso');

--- a/app/Repositories/PessoaRepository.php
+++ b/app/Repositories/PessoaRepository.php
@@ -360,19 +360,24 @@ class PessoaRepository extends BaseRepository
     public function updateSegmentos(Pessoa $pessoa)
     {
         $this->startConnectorVestylle();
-        $retornoVestylle = $this->vestylleDB->getSegmentosPessoa($pessoa);
+        $retornoVestylle = $this->vestylleDB->getSegmentosPessoa($pessoa);                
         
-        if ($retornoVestylle) {                              
+        if ($retornoVestylle->count() > 0) {                              
+
             foreach ($retornoVestylle as $categoria) {            
                 $categoria->conteudo = strtoupper($categoria->conteudo);                                
-                $categoriaIds[] = Categoria::where((array) $categoria)->get()->first()->id;
+                $categorias = Categoria::where((array) $categoria)->get()->first();                
+                if ($categorias) {
+                    $categoriaIds[] = $categorias->id;
+                }                
+            }            
+
+            if (isset($categoriaIds) && count($categoriaIds) > 0) {
+                $pessoa->segmentacoes()->whereNotIn('categoria_id', $categoriaIds)->delete();
                 
-            }
-            
-            $pessoa->segmentacoes()->whereNotIn('categoria_id', $categoriaIds)->delete();
-            
-            foreach ($categoriaIds as $categoriaId) {
-                $pessoa->segmentacoes()->create(['categoria_id' => $categoriaId]);
+                foreach ($categoriaIds as $categoriaId) {
+                    $pessoa->segmentacoes()->create(['categoria_id' => $categoriaId]);
+                }
             }
         }
         

--- a/database/seeds/PessoasTableSeeder.php
+++ b/database/seeds/PessoasTableSeeder.php
@@ -32,12 +32,13 @@ class PessoasTableSeeder extends Seeder
 
             if ($pessoaApp->count() == 0) {
                 $pessoaCriada = $repositorio->createFromVestylle($pessoa->cnpj_cpf);
-                $this->command->info(".");
+                $this->command->info("Trazendo dados da pessoa ".$pessoaCriada->nome);
 
                 if (env('SEED_DADOS_PESSOA')) {
                     $repositorio->updatePontosPessoa($pessoaCriada);
                     $repositorio->updateVencimentoPontosPessoa($pessoaCriada);
                     $repositorio->updateDataUltimaCompraPessoa($pessoaCriada);
+                    $repositorio->updateNascimentoPessoa($pessoaCriada);
                 }
             }
             else {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165947767

**Para testar**
1 - Alterar .env `SEED_DADOS_PESSOA=true` 
2 - Rodar `composer dump-autoload`, `php artisan cache:clear`, `php artisan clear-compiled`
3 - Rodar `migrate:fresh --seed` e observar coluna `data_nascimento` em nossa base
4 - Criar novo usuário pelo Postman, passando um CPF válido e que exista na base da vestylle. Exemplos: 80208410759 (tem categorias) ou 71102205834 (não tem categorias) - tem que garantir que o mesmo não está presente em nossa base por causa da regra unique. Se for o caso, aplicar um forceDelete() pra remover a pessoa de nossa base.
5 - Rodar `php artisan vestylle:atualiza-ultimos-compradores` - verificar se não quebrou. Em tese, essa rotina também atualiza data_nasc da pessoa.
6 - Verificar se há segmentações associadas as pessoas, pois eu precisei mexer nessa parte nessa branch