### PR TITLE
Feature/166126753 - Alterar listagem de Cupons e Ofertas pra considerar segmentações

### DIFF
--- a/app/Http/Controllers/API/CuponAPIController.php
+++ b/app/Http/Controllers/API/CuponAPIController.php
@@ -40,8 +40,9 @@ class CuponAPIController extends AppBaseController
         $this->cuponRepository->pushCriteria(new RequestCriteria($request));
         $this->cuponRepository->pushCriteria(new LimitOffsetCriteria($request));
 
+        $pessoa = Auth('api')->user();
         //Atenção que o apareceListagem do repositorio precisa ser chamado antes!
-        $cupons = $this->cuponRepository->apareceListagem()->with('fotos')->get();
+        $cupons = $this->cuponRepository->apareceListagem($pessoa);
         return $this->sendResponse($cupons->toArray(), 'Cupons carregados com sucesso');
     }
 

--- a/app/Http/Controllers/API/OfertaAPIController.php
+++ b/app/Http/Controllers/API/OfertaAPIController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API;
 
+use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\API\CreateOfertaAPIRequest;
 use App\Http\Requests\API\UpdateOfertaAPIRequest;
 use App\Models\Oferta;
@@ -38,7 +39,10 @@ class OfertaAPIController extends AppBaseController
     {
         $this->ofertaRepository->pushCriteria(new RequestCriteria($request));
         $this->ofertaRepository->pushCriteria(new LimitOffsetCriteria($request));
-        $ofertas = $this->ofertaRepository->with(['cupons', 'fotos'])->all();
+        
+        $pessoa = Auth('api')->user();
+
+        $ofertas = $this->ofertaRepository->apareceListagem($pessoa);
 
         return $this->sendResponse($ofertas->toArray(), 'Ofertas encontradas com sucesso');
     }

--- a/app/Http/Controllers/QRCodeController.php
+++ b/app/Http/Controllers/QRCodeController.php
@@ -39,7 +39,6 @@ class QRCodeController extends Controller
         $cupon->save();
         $valorQRCode = env('URL_FRONT_CUPON').md5($cupon->qrcode);
         
-
         $filePath = "uploads/$cupon->titulo.png";
         $qrcode = \QrCode::format('png')->size(500)->generate($valorQRCode, $filePath);
 

--- a/app/Models/Cupon.php
+++ b/app/Models/Cupon.php
@@ -171,7 +171,7 @@ class Cupon extends Model
     }
 
     /**
-     * Scope a query to only include popular users.
+     * Scope pra trazer listagem segmentada com base nas categorias da pessoa
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
@@ -188,7 +188,7 @@ class Cupon extends Model
     }
 
     /**
-     * Scope a query to only include popular users.
+     * Scope pra trazer listagem sem segmentação
      *
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder

--- a/app/Models/Cupon.php
+++ b/app/Models/Cupon.php
@@ -170,4 +170,32 @@ class Cupon extends Model
         return self::where('qrcode', $idEncryptado)->get()->first();
     }
 
+    /**
+     * Scope a query to only include popular users.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSegmentadosPorUsuario($query, $pessoa)
+    {
+        $categoriasPessoa = $pessoa->categorias->pluck('id')->toArray();
+
+        return $query->whereHas(
+            'categorias', function ($query) use ($categoriasPessoa) { 
+                $query->whereIn('owner_id', $categoriasPessoa);
+            }
+        );        
+    }
+
+    /**
+     * Scope a query to only include popular users.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeNaoSegmentados($query)
+    {
+        return $query->doesntHave('categorias');
+    }
+
 }

--- a/app/Models/Cupon.php
+++ b/app/Models/Cupon.php
@@ -182,7 +182,7 @@ class Cupon extends Model
 
         return $query->whereHas(
             'categorias', function ($query) use ($categoriasPessoa) { 
-                $query->whereIn('owner_id', $categoriasPessoa);
+                $query->whereIn('categoria_id', $categoriasPessoa);
             }
         );        
     }

--- a/app/Models/Oferta.php
+++ b/app/Models/Oferta.php
@@ -132,4 +132,32 @@ class Oferta extends Model
         $this->attributes['preco'] = str_replace(',', '.', $value);
     }
 
+    /**
+     * Scope pra trazer listagem segmentada com base nas categorias da pessoa
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSegmentadosPorUsuario($query, $pessoa)
+    {
+        $categoriasPessoa = $pessoa->categorias->pluck('id')->toArray();
+
+        return $query->whereHas(
+            'categorias', function ($query) use ($categoriasPessoa) { 
+                $query->whereIn('categoria_id', $categoriasPessoa);
+            }
+        );        
+    }
+
+    /**
+     * Scope pra trazer listagem sem segmentação
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeNaoSegmentados($query)
+    {
+        return $query->doesntHave('categorias');
+    }
+
 }

--- a/app/Repositories/CuponRepository.php
+++ b/app/Repositories/CuponRepository.php
@@ -52,12 +52,23 @@ class CuponRepository extends BaseRepository
 
     /**
      * Get Cupons que tem 'aparece_listagem' marcado como true
+     * Mescla cupons segmentados pra uma pessoa, e cupons sem segmentos
      *
      * @return Collection
      */
-    public function apareceListagem()
+    public function apareceListagem($pessoa)
     {
-        return $this->model()::apareceListagem();
+        if (!is_null($pessoa)) {
+            $cuponsSegmentados = $this->model()::with('fotos')->apareceListagem()
+                ->SegmentadosPorUsuario($pessoa)->get();
+        }
+
+        $cuponsNaoSegmentados = $this->model()::with('fotos')->apareceListagem()
+            ->NaoSegmentados()->get();
+        
+        $cupons = $cuponsSegmentados->merge($cuponsNaoSegmentados);
+        
+        return $cupons;
     }
 
 }

--- a/app/Repositories/OfertaRepository.php
+++ b/app/Repositories/OfertaRepository.php
@@ -31,4 +31,25 @@ class OfertaRepository extends BaseRepository
     {
         return Oferta::class;
     }
+
+    /**
+     * Get Ofertas 
+     * Mescla ofertas segmentados pra uma pessoa, e ofertas sem segmentos
+     *
+     * @return Collection
+     */
+    public function apareceListagem($pessoa)
+    {
+        if (!is_null($pessoa)) {
+            $ofertasSegmentados = $this->model()::with(['cupons', 'fotos'])
+                ->SegmentadosPorUsuario($pessoa)->get();
+        }
+
+        $ofertasNaoSegmentados = $this->model()::with(['cupons', 'fotos'])
+            ->NaoSegmentados()->get();
+        
+        $ofertas = $ofertasSegmentados->merge($ofertasNaoSegmentados);
+        
+        return $ofertas;
+    }
 }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166126753

*Para testar*

1. Sincronizar base com a base vestylle: `migrate:fresh --seed`
2. Identificar na nossa base, alguma pessoa que possua uma ou mais categorias associadas, através do relacionamento `$pessoa->categorias` . Dê preferência pra pessoas que possuem mais de uma categoria associadas pra que o teste fique mais fiel. Anote as categorias da pessoa
3. No webadmin, associe cupons e ofertas a essas categorias, de forma aleatória. Abuse das combinações possíveis, colocando cupom em uma categoria, oferta em outras duas, etc..
4. No postman, acesse a rota de login e autentique com o usuário escolhido no passo 2 e anote o token retornado. 
5. Teste as rotas de listagem (GET) de Ofertas e Cupons. Você vai precisar passar o token na variável `{{user_token}}`, que encontra-se na configuração do Environment. Essa etapa é essencial, pois a API identifica a segmentação através do usuário, e sem isso, não vai ser possível efetuar o teste.
6. O retorno das rotas de listagem devem conter: cupons e ofertas *não segmentados*, e, ofertas e cupons associados a *mesma categoria da pessoa escolhido no passo 2*
