### PR TITLE
Bugfix | #166189954 | Corrigindo show de Ofertas e Cupons

### DIFF
--- a/resources/views/cupons/show_fields.blade.php
+++ b/resources/views/cupons/show_fields.blade.php
@@ -1,5 +1,5 @@
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-4">
         <div class="form-group">
             {!! Form::label('titulo', 'Título') !!}
             <p>{!! $cupon->titulo !!}</p>
@@ -45,13 +45,6 @@
             {!! Form::label('updated_at', 'Atualizado Em:') !!}
             <p>{!! $cupon->updated_at !!}</p>
         </div>
-    </div>
-    <div class="col-md-6">
-        @if ($cupon->fotos)
-            <div class="form-group">
-                <image-slider :images="{{ $cupon->fotos }}"></image-slider>
-            </div>
-        @endif
 
         @if ($cupon->categorias()->count())
             <div class="form-group">
@@ -63,5 +56,13 @@
                 </ul>
             </div>
         @endif
+    </div>
+    <div class="col-md-8">
+        @if ($cupon->fotos)
+            <div class="form-group">
+                <image-slider :images="{{ $cupon->fotos }}"></image-slider>
+            </div>
+        @endif
+
     </div>
 </div>

--- a/resources/views/ofertas/show_fields.blade.php
+++ b/resources/views/ofertas/show_fields.blade.php
@@ -1,5 +1,5 @@
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-4">
         <!-- Id Field -->
         <div class="form-group">
             {!! Form::label('id', 'Id:') !!}
@@ -40,16 +40,6 @@
             <p>{!! $oferta->updated_at !!}</p>
         </div>
 
-    </div>
-
-    <div class="col-md-6">
-        @if ($oferta->fotos()->count())
-            <div class="form-group">
-                {!! Form::label('fotos', 'Fotos:') !!}
-                <image-slider :images="{{ $oferta->fotos }}"></image-slider>
-            </div>
-        @endif
-
         @if ($oferta->categorias()->count())
             <div class="form-group">
                 {!! Form::label('categorias', 'Categorias:') !!}
@@ -60,5 +50,16 @@
                 </ul>
             </div>
         @endif
+
+    </div>
+
+    <div class="col-md-8">
+        @if ($oferta->fotos()->count())
+            <div class="form-group">
+                {!! Form::label('fotos', 'Fotos:') !!}
+                <image-slider :images="{{ $oferta->fotos }}"></image-slider>
+            </div>
+        @endif
+
     </div>
 </div>


### PR DESCRIPTION
[Link Pivotal](https://www.pivotaltracker.com/story/show/166189954)

Antes a listagem das fotos de uma oferta ou cupon estavam estourando a largura da pagina.