### PR TITLE
166276184 | corrige comportamento do upload de imagens

### DIFF
--- a/resources/js/components/VueUploadMultipleImage.vue
+++ b/resources/js/components/VueUploadMultipleImage.vue
@@ -36,6 +36,8 @@
                 this.getImagePreviews();
             },
             handleFiles() {
+                this.files = [];
+
                 let uploadedFiles = this.$refs.files.files;
 
                 if (uploadedFiles.length > 10 || this.files.length == 10) {


### PR DESCRIPTION
Agora aceita um ou vários arquivos, com isso não tem mais a possibilidade de ir adicionando um por um antes de salvar e conserta a falha de subir vários arquivos na página e só salvar o último.