### PR TITLE
Bugfix/167516514 - Filtrando cupons vencidos na listagem de cupons

### DIFF
--- a/app/Models/Cupon.php
+++ b/app/Models/Cupon.php
@@ -300,6 +300,16 @@ class Cupon extends Model
     }
 
     /**
+     * Scope para filtrar cupons com data de vencimento expirada
+     */
+    public function scopeNaoVencidos($query)
+    {
+        $now = \Carbon\Carbon::now();
+
+        return $query->where('data_validade', '>=', $now);
+    }
+
+    /**
      * Scope para aplicar na query filtrando por cupons que foram utilizados pela $pessoa
      */
     public function scopeUtilizadoVenda($query, $pessoa)

--- a/app/Repositories/CuponRepository.php
+++ b/app/Repositories/CuponRepository.php
@@ -73,12 +73,15 @@ class CuponRepository extends BaseRepository
     public function apareceListagem($pessoa)
     {
         $cuponsNaoSegmentados = $this->model()::with('fotos')->apareceListagem()
-            ->NaoSegmentados()->get();
+            ->NaoVencidos()
+            ->NaoSegmentados()
+            ->get();
 
         //Se pessoa: devemos considerar segmentacao e excluir cupons 'ja utilizados no caixa'
         if (!is_null($pessoa)) {
 
             $cuponsSegmentados = $this->model()::with('fotos')->apareceListagem()
+                ->NaoVencidos()
                 ->SegmentadosPorUsuario($pessoa)
                 ->get();
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167516514

Para testar:
1 - Alterar data de vencimento de um cupom qualquer pra uma data anterior a hoje
2 - Verificar listagem de cupons - o mesmo nao deve aparecer
3 - Repetir o teste pra cupons segmentados 
3.1 - Cadastrar um cupom segmentado - com data de validade maior do que hoje
3.2 - Efetuar login com segmentos iguais ao cupom
3.3 - Verificar listagem de cupons - cupom deve aparecer
3.4 - Repetir o teste alterando a data de validade do cupom pra antes de hoje