### PR TITLE
Bugfix/167516410 - Erro ao excluir pessoa que tem um fale conosco associado

### DIFF
--- a/app/Http/Controllers/PessoaController.php
+++ b/app/Http/Controllers/PessoaController.php
@@ -152,6 +152,7 @@ class PessoaController extends AppBaseController
         $pessoa->cupons()->detach();
         $pessoa->listaDesejos()->detach();
         $pessoa->categorias()->detach();
+        $pessoa->faleConoscos()->forceDelete();
 
         $this->pessoaRepository->delete($id);
 

--- a/app/Models/Pessoa.php
+++ b/app/Models/Pessoa.php
@@ -139,6 +139,16 @@ class Pessoa extends Authenticatable
     }
 
     /**
+     * Relacionamento N x N entre cupons e pessoas
+     *
+     * @return relationship
+     */
+    public function faleConoscos()
+    {
+        return $this->hasMany('App\Models\FaleConosco');
+    }
+
+    /**
      * Mutator para a dataNascimento
      */
     public function setDataNascimentoAttribute($value)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167516410

Para testar:
1 - Cadastrar um fale conosco associado a uma pessoa_id
2 - Excluir a pessoa